### PR TITLE
Remove conversation title from messages so it doesn't repeat

### DIFF
--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -10,14 +10,12 @@ $(document).ready(function() {
       url: $(form).attr('action'),
       method: $(form).attr('method'),
       data: $(form).serialize()
-
     })
     ajaxRequest.done(function(response){
-      console.log(response);
       $('#chat-sm').html(response);
       $('#btn-input').val("");
       $("html, body").animate({ scrollTop: $(document).height() }, "slow");
-  return false;
+      return false;
     });
   });
 

--- a/app/views/messages/create.html.erb
+++ b/app/views/messages/create.html.erb
@@ -1,6 +1,3 @@
-<div class="panel-heading">
-  <h3 class="panel-title">Conversation</h3>
-</div>
 <div class="chat" id="chat">
   <% @all_messages.each do |message| %>
     <% if current_user.name == message.user.name %>


### PR DESCRIPTION
The panel heading"Conversation" was repeating upon sending a text message, so we deleted it from the Messages#create show.
